### PR TITLE
Optional support for CSS with cssnext

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.16.0",
     "babel-runtime": "^6.6.1",
+    "caniuse-lite": "^1.0.30000700",
     "css-loader": "0.14.5",
     "eslint": "^3.10.1",
     "eslint-config-airbnb": "^13.0.0",
@@ -39,6 +40,9 @@
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.24.1",
     "node-sass": "^3.13.0",
+    "postcss": "^6.0.6",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^10.0.0",
     "postcss-loader": "^1.1.1",
     "prepush": "^3.1.11",
     "redux-logger": "^2.7.4",
@@ -69,7 +73,7 @@
   "description": "Starter boilerplate for React and Redux, using Webpack 2",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/Stanko/react-redux-webpack2-boilerplate.git"
+    "url": "git+ssh://git@github.com:workco/marvin.git"
   },
   "keywords": [
     "react",
@@ -79,9 +83,9 @@
   ],
   "author": "Stanko",
   "bugs": {
-    "url": "https://github.com/Stanko/react-redux-webpack2-boilerplate/issues"
+    "url": "https://github.com/workco/marvin/issues"
   },
-  "homepage": "https://github.com/Stanko/react-redux-webpack2-boilerplate#readme",
+  "homepage": "https://github.com/workco/marvin#readme",
   "prepush": [
     "npm run lint-break-on-errors --silent"
   ]

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  plugins: {
+    'postcss-import': {
+      path: 'source/css/',
+    },
+    'postcss-cssnext': {
+      browsers: ['last 2 versions', '> 5%'],
+    },
+  },
+};

--- a/source/css/base/app.css
+++ b/source/css/base/app.css
@@ -1,43 +1,35 @@
-$font-family-serif: Garamond, "Times New Roman", serif;
-$font-family-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
-
-$grey-border: #eee;
-$grey-text: #aaa;
-$black: #000;
-$white: #fff;
-
 html {
   font-size: 10px;
 
-  @include lg {
+  @media (--lg) {
     font-size: 12px;
   }
 
-  @include xl {
+  @media (--xl) {
     font-size: 14px;
   }
 }
 
 body {
-  color: $black;
-  font-family: $font-family-sans-serif;
+  color: var(--black);
+  font-family: var(--font-family-sans-serif);
 }
 
 .App {
   font-size: 1.8rem;
   padding: 2rem;
 
-  @include md {
+  @media (--md) {
     padding: 4rem;
   }
 }
 
 a {
-  color: $grey-text;
+  color: var(--grey-text);
 }
 
 a:hover {
-  color: $black;
+  color: var(--black);
 }
 
 h1,
@@ -61,7 +53,7 @@ h3 {
 button {
   background: transparent;
   border-radius: 1.6rem;
-  border: 0.1rem solid $black;
+  border: 0.1rem solid var(--black);
   cursor: pointer;
   font-size: 1.5rem;
   padding: 0.7rem 2rem;
@@ -72,19 +64,19 @@ button:disabled {
 }
 
 button:hover {
-  background: $white;
+  background: var(--white);
 }
 
 .Menu {
   align-items: center;
-  border-bottom: 1px solid $grey-border;
+  border-bottom: 1px solid var(--grey-border);
   display: flex;
   justify-content: space-between;
   padding-bottom: 2rem;
   margin: 0 auto 2rem;
   max-width: 60rem;
 
-  @include lg {
+  @media (--lg) {
     margin-left: 20rem;
     margin: 0 0 2rem 20rem;
     padding-bottom: 0;
@@ -99,49 +91,44 @@ button:hover {
   margin-right: 2rem;
   width: 6rem;
 
-  @include lg {
+  @media (--lg) {
     position: fixed;
     height: 100vh;
     top: 0;
     left: 0;
-    border-right: 1px solid $grey-border;
+    border-right: 1px solid var(--grey-border);
     width: 20rem;
     padding: 4rem;
   }
 }
 
-.Menu-links {
-  @include md {
-  }
-}
-
 .Menu-link {
   display: inline-block;
-  font-family: $font-family-serif;
+  font-family: var(--font-family-serif);;
   font-style: italic;
   margin-left: 1.5rem;
   line-height: 3rem;
   text-decoration: none;
 
-  @include md {
+  @media (--md) {
     margin-left: 3rem;
   }
 
-  @include lg {
+  @media (--lg) {
     margin: 0 3rem 0 0;
     line-height: 7.5rem;
   }
 }
 
 .Menu-link--active {
-  color: $black;
+  color: var(--black);
 }
 
 .Page {
   max-width: 60rem;
   margin: 0 auto;
 
-  @include lg {
+  @media (--lg) {
     margin: 0 0 0 20rem;
   }
 }
@@ -171,6 +158,6 @@ button:hover {
 
 hr {
   border: 0;
-  border-top: 1px solid $grey-border;
+  border-top: 1px solid var(--grey-border);
   margin: 2rem 0;
 }

--- a/source/css/base/reset.css
+++ b/source/css/base/reset.css
@@ -1,0 +1,457 @@
+/*! normalize.css v4.1.1 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Change the default font family in all browsers (opinionated).
+ * 2. Prevent adjustments of font size after orientation changes in IE and iOS.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove the margin in all browsers (opinionated).
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ * 2. Add the correct display in IE.
+ */
+
+article,
+aside,
+details, /* 1 */
+figcaption,
+figure,
+footer,
+header,
+main, /* 2 */
+menu,
+nav,
+section,
+summary { /* 1 */
+  display: block;
+}
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in iOS 4-7.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Add the correct display in IE 10-.
+ * 1. Add the correct display in IE.
+ */
+
+template, /* 1 */
+[hidden] {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ */
+
+a {
+  background-color: transparent; /* 1 */
+  -webkit-text-decoration-skip: objects; /* 2 */
+}
+
+/**
+ * Remove the outline on focused links when they are also active or hovered
+ * in all browsers (opinionated).
+ */
+
+a:active,
+a:hover {
+  outline-width: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * 1. Remove the bottom border in Firefox 39-.
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
+ */
+
+b,
+strong {
+  font-weight: inherit;
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * Add the correct font style in Android 4.3-.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Add the correct background and color in IE 9-.
+ */
+
+mark {
+  background-color: #ff0;
+  color: #000;
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10-.
+ */
+
+img {
+  border-style: none;
+  max-width: 100%;
+}
+
+/**
+ * Hide the overflow in IE.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct margin in IE 8.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change font properties to `inherit` in all browsers (opinionated).
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+select,
+textarea {
+  font: inherit; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Restore the font weight unset by the previous rule.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+ *    controls in Android 4.
+ * 2. Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+html [type="button"], /* 1 */
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Change the border, margin, and padding in all browsers (opinionated).
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Remove the default vertical scrollbar in IE.
+ */
+
+textarea {
+  overflow: auto;
+  resize: none;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10-.
+ * 2. Remove the padding in IE 10-.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
+ */
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Correct the text style of placeholders in Chrome, Edge, and Safari.
+ */
+
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+*,
+*::after,
+*::before {
+  box-sizing: border-box;
+}
+
+svg {
+    max-width: 100%;
+}
+
+/**
+ * Hack to remove Chrome's yellow background on autofilling inputs
+ */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+    transition: background-color 500000s ease-in-out 0s, color 500000s ease-in-out 0s;
+}
+
+/**
+ * Fix for IE select bars
+ */
+select::-ms-value,
+select:focus::-ms-value {
+    background: none;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+p {
+    margin: 0 0 1em 0;
+}

--- a/source/css/base/vars.css
+++ b/source/css/base/vars.css
@@ -1,0 +1,14 @@
+:root {
+  --font-family-serif: Garamond, "Times New Roman", serif;
+  --font-family-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+  --grey-border: #eee;
+  --grey-text: #aaa;
+  --black: #000;
+  --white: #fff;
+}
+
+@custom-media --sm (max-width: 500px);
+@custom-media --md (min-width: 769px);
+@custom-media --lg (min-width: 1025px);
+@custom-media --xl (min-width: 2000px);

--- a/source/css/index.css
+++ b/source/css/index.css
@@ -1,0 +1,3 @@
+@import "base/vars";
+@import "base/reset";
+@import "base/app";

--- a/source/js/index.js
+++ b/source/js/index.js
@@ -10,8 +10,12 @@ import rootReducer from 'reducers';
 
 import App from 'views/App';
 
-// Load SCSS
-import '../css/index.css';
+/**
+ * This loads the SCSS/CSS file.
+ * For more info, refer to the README, or webpack.config.js
+ */
+import '../scss/app.scss';
+// import '../css/index.css';
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/source/js/index.js
+++ b/source/js/index.js
@@ -11,7 +11,7 @@ import rootReducer from 'reducers';
 import App from 'views/App';
 
 // Load SCSS
-import '../scss/app.scss';
+import '../css/index.css';
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,19 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const SpritePlugin = require('svg-sprite-loader/plugin');
 
+/**
+ * Marvin supports the use of either:
+ * - SCSS pre-processor, with PostCSS autoprefixer plugin
+ * - CSS with PostCSS import and css-next plugins
+ *
+ * SCSS is enabled by default. To switch to using CSS,
+ * switch the commented-out `cssConfig` variable below.
+ * Also, change the css entry point in the application
+ * at source/js/index.js
+ */
+const cssConfig = require('./webpack/scss');
+// const cssConfig = require('./webpack/postcss');
+
 const nodeEnv = process.env.NODE_ENV || 'development';
 const isProduction = nodeEnv === 'production';
 
@@ -39,6 +52,10 @@ const plugins = [
     filename: 'index.html',
   }),
 ];
+
+if (cssConfig.plugin) {
+  plugins.push(cssConfig.plugin);
+}
 
 // Common rules
 const rules = [
@@ -94,21 +111,7 @@ if (isProduction) {
   );
 
   // Production rules
-  rules.push(
-    {
-      test: /\.css$/,
-      loader: ExtractTextPlugin.extract({
-        fallback: 'style-loader',
-        use: [
-          {
-            loader: 'css-loader',
-            options: { importLoaders: 1 },
-          },
-          'postcss-loader',
-        ],
-      }),
-    }
-  );
+  rules.push(cssConfig.rules.prod);
 } else {
   // Development plugins
   plugins.push(
@@ -117,29 +120,7 @@ if (isProduction) {
   );
 
   // Development rules
-  rules.push(
-    {
-      test: /\.css$/,
-      exclude: /node_modules/,
-      use: [
-        {
-          loader: 'style-loader',
-          options: { sourceMap: true },
-        },
-        {
-          loader: 'css-loader',
-          options: {
-            importLoaders: 1,
-            sourceMap: true,
-          },
-        },
-        {
-          loader: 'postcss-loader',
-          options: { sourceMap: true },
-        },
-      ],
-    }
-  );
+  rules.push(cssConfig.rules.dev);
 }
 
 module.exports = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ const DashboardPlugin = require('webpack-dashboard/plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const SpritePlugin = require('svg-sprite-loader/plugin');
-const autoprefixer = require('autoprefixer');
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 const isProduction = nodeEnv === 'production';
@@ -38,19 +37,6 @@ const plugins = [
     template: path.join(sourcePath, 'index.html'),
     path: buildPath,
     filename: 'index.html',
-  }),
-  new webpack.LoaderOptionsPlugin({
-    options: {
-      postcss: [
-        autoprefixer({
-          browsers: [
-            'last 3 version',
-            'ie >= 10',
-          ],
-        }),
-      ],
-      context: sourcePath,
-    },
   }),
 ];
 
@@ -110,10 +96,16 @@ if (isProduction) {
   // Production rules
   rules.push(
     {
-      test: /\.scss$/,
+      test: /\.css$/,
       loader: ExtractTextPlugin.extract({
         fallback: 'style-loader',
-        use: 'css-loader!postcss-loader!sass-loader',
+        use: [
+          {
+            loader: 'css-loader',
+            options: { importLoaders: 1 },
+          },
+          'postcss-loader',
+        ],
       }),
     }
   );
@@ -127,18 +119,24 @@ if (isProduction) {
   // Development rules
   rules.push(
     {
-      test: /\.scss$/,
+      test: /\.css$/,
       exclude: /node_modules/,
       use: [
-        'style-loader',
-        // Using source maps breaks urls in the CSS loader
-        // https://github.com/webpack/css-loader/issues/232
-        // This comment solves it, but breaks testing from a local network
-        // https://github.com/webpack/css-loader/issues/232#issuecomment-240449998
-        // 'css-loader?sourceMap',
-        'css-loader',
-        'postcss-loader',
-        'sass-loader?sourceMap',
+        {
+          loader: 'style-loader',
+          options: { sourceMap: true },
+        },
+        {
+          loader: 'css-loader',
+          options: {
+            importLoaders: 1,
+            sourceMap: true,
+          },
+        },
+        {
+          loader: 'postcss-loader',
+          options: { sourceMap: true },
+        },
       ],
     }
   );

--- a/webpack/postcss.js
+++ b/webpack/postcss.js
@@ -1,0 +1,40 @@
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+module.exports = {
+  rules: {
+    prod: {
+      test: /\.css$/,
+      loader: ExtractTextPlugin.extract({
+        fallback: 'style-loader',
+        use: [
+          {
+            loader: 'css-loader',
+            options: { importLoaders: 1 },
+          },
+          'postcss-loader',
+        ],
+      }),
+    },
+    dev: {
+      test: /\.css$/,
+      exclude: /node_modules/,
+      use: [
+        {
+          loader: 'style-loader',
+          options: { sourceMap: true },
+        },
+        {
+          loader: 'css-loader',
+          options: {
+            importLoaders: 1,
+            sourceMap: true,
+          },
+        },
+        {
+          loader: 'postcss-loader',
+          options: { sourceMap: true },
+        },
+      ],
+    },
+  },
+};

--- a/webpack/scss.js
+++ b/webpack/scss.js
@@ -1,0 +1,47 @@
+const webpack = require('webpack');
+const path = require('path');
+
+const autoprefixer = require('autoprefixer');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+const sourcePath = path.join(__dirname, '../source');
+
+module.exports = {
+  plugin: new webpack.LoaderOptionsPlugin({
+    options: {
+      postcss: [
+        autoprefixer({
+          browsers: [
+            'last 3 version',
+            'ie >= 10',
+          ],
+        }),
+      ],
+      context: sourcePath,
+    },
+  }),
+  rules: {
+    prod: {
+      test: /\.scss$/,
+      loader: ExtractTextPlugin.extract({
+        fallback: 'style-loader',
+        use: 'css-loader!postcss-loader!sass-loader',
+      }),
+    },
+    dev: {
+      test: /\.scss$/,
+      exclude: /node_modules/,
+      use: [
+        'style-loader',
+        // Using source maps breaks urls in the CSS loader
+        // https://github.com/webpack/css-loader/issues/232
+        // This comment solves it, but breaks testing from a local network
+        // https://github.com/webpack/css-loader/issues/232#issuecomment-240449998
+        // 'css-loader?sourceMap',
+        'css-loader',
+        'postcss-loader',
+        'sass-loader?sourceMap',
+      ],
+    },
+  },
+};


### PR DESCRIPTION
I wanted to give users the option to use regular 'ol CSS, but with PostCSS plugins for handling imports (https://github.com/postcss/postcss-import) and for "using tomorrow's CSS syntax, today" (https://github.com/MoOx/postcss-cssnext).

@Stanko wanted to keep support for SCSS, so I tried to make the webpack CSS config modular. However, there's still two points where the user would need to comment out lines to make the repo work with CSS, which is pretty janky. Am open to suggestions for improving this.

