### PR TITLE
Order of plugins matters!

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,8 @@
 {
   "plugins": [
+    "transform-decorators-legacy",
     "transform-class-properties",
-    "syntax-decorators",
-    "transform-decorators-legacy"
+    "syntax-decorators"
   ],
   "presets": [
     ["es2015", { "modules": false }],


### PR DESCRIPTION
Make sure that `transform-decorators-legacy` comes before `transform-class-properties`.

https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#note-order-of-plugins-matters