### PR TITLE
Add Hygen templating

### DIFF
--- a/_templates/component/new/action.ejs.t
+++ b/_templates/component/new/action.ejs.t
@@ -1,0 +1,14 @@
+---
+to: source/js/actions/<%= name %>.js
+---
+
+export const GET_<%= name.toUpperCase() %>_START = "GET_<%= name.toUpperCase() %>_START";
+export const GET_<%= name.toUpperCase() %>_ERROR = "GET_<%= name.toUpperCase() %>_ERROR";
+export const GET_<%= name.toUpperCase() %>_SUCCESS = "GET_<%= name.toUpperCase() %>_SUCCESS";
+
+
+export function get<%= h.capitalize(name) %>() {
+  return {
+    type: GET_<%= name.toUpperCase() %>_START,
+  };
+}

--- a/_templates/component/new/component.ejs.t
+++ b/_templates/component/new/component.ejs.t
@@ -1,0 +1,17 @@
+---
+to: source/js/components/<%= name %>.js
+---
+
+import React, { Component } from 'react';
+
+export default class <%= h.capitalize(name) %> extends Component {
+  render() {
+    return (
+      <div className='<%= h.capitalize(name) %>'>
+        
+      </div>
+    );
+  }
+}
+
+

--- a/_templates/component/new/inject-reducer.ejs.t
+++ b/_templates/component/new/inject-reducer.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: source/js/reducers/index.js
+after: 'import { combineReducers } from "redux";'
+skip_if: "import <%= name %> from 'reducers/<%= name %>';"
+---
+import <%= name %> from 'reducers/<%= name %>';

--- a/_templates/component/new/reducer.ejs.t
+++ b/_templates/component/new/reducer.ejs.t
@@ -1,0 +1,45 @@
+---
+to: source/js/reducers/<%= name %>.js
+---
+
+import { Map } from 'immutable';
+
+import {
+  GET_<%= name.toUpperCase() %>_START,
+  GET_<%= name.toUpperCase() %>_ERROR,
+  GET_<%= name.toUpperCase() %>_SUCCESS,
+} from 'actions/<%= name %>';
+
+const initialState = Map({
+  loading: false,
+  error: null,
+  <%= name %>: null,
+});
+
+const actionsMap = {
+  // Async action
+  [GET_<%= name.toUpperCase() %>_START]: (state) => {
+    return state.merge(Map({
+      loading: true,
+      error: null,
+      <%= name %>: null,
+    }));
+  },
+  [GET_<%= name.toUpperCase() %>_ERROR]: (state, action) => {
+    return state.merge(Map({
+      loading: false,
+      error: action.error.message,
+    }));
+  },
+  [GET_<%= name.toUpperCase() %>_SUCCESS]: (state, action) => {
+    return state.merge(Map({
+      loading: false,
+      <%= name %>: action.data,
+    }));
+  },
+};
+
+export default function reducer(state = initialState, action = {}) {
+  const fn = actionsMap[action.type];
+  return fn ? fn(state, action) : state;
+}

--- a/_templates/component/new/register-reducer.ejs.t
+++ b/_templates/component/new/register-reducer.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: source/js/reducers/index.js
+after: "export default combineReducers\\(\\{"
+skip_if: "<%= name %>,"
+---
+  <%= name %>,

--- a/_templates/generator/help/index.ejs.t
+++ b/_templates/generator/help/index.ejs.t
@@ -1,0 +1,5 @@
+---
+message: |
+  hygen {bold generator new} --name [NAME] --action [ACTION]
+  hygen {bold generator with-prompt} --name [NAME] --action [ACTION]
+---

--- a/_templates/generator/new/hello.ejs.t
+++ b/_templates/generator/new/hello.ejs.t
@@ -1,0 +1,18 @@
+---
+to: _templates/<%= name %>/<%= action || 'new' %>/hello.ejs.t
+---
+---
+to: app/hello.js
+---
+const hello = ```
+Hello!
+This is your first hygen template.
+
+Learn what it can do here:
+
+https://github.com/jondot/hygen
+```
+
+console.log(hello)
+
+

--- a/_templates/generator/with-prompt/hello.ejs.t
+++ b/_templates/generator/with-prompt/hello.ejs.t
@@ -1,0 +1,18 @@
+---
+to: _templates/<%= name %>/<%= action || 'new' %>/hello.ejs.t
+---
+---
+to: app/hello.js
+---
+const hello = ```
+Hello!
+This is your first prompt based hygen template.
+
+Learn what it can do here:
+
+https://github.com/jondot/hygen
+```
+
+console.log(hello)
+
+

--- a/_templates/generator/with-prompt/prompt.ejs.t
+++ b/_templates/generator/with-prompt/prompt.ejs.t
@@ -1,0 +1,16 @@
+---
+to: _templates/<%= name %>/<%= action || 'new' %>/prompt.js
+---
+
+// see types of prompts:
+// https://github.com/SBoudrias/Inquirer.js#prompt-types
+//
+// and for examples for prompts:
+// https://github.com/SBoudrias/Inquirer.js/tree/master/examples
+module.exports = [
+  {
+    type: 'input',
+    name: 'message',
+    message: "What's your message?"
+  }
+]

--- a/_templates/module/new/action.ejs.t
+++ b/_templates/module/new/action.ejs.t
@@ -1,0 +1,12 @@
+---
+to: source/js/actions/<%= name %>.js
+---
+
+export const GET_<%= name.toUpperCase() %>_START = 'GET_<%= name.toUpperCase() %>_START';
+export const GET_<%= name.toUpperCase() %>_ERROR = 'GET_<%= name.toUpperCase() %>_ERROR';
+export const GET_<%= name.toUpperCase() %>_SUCCESS = 'GET_<%= name.toUpperCase() %>_SUCCESS';
+
+
+export const get<%= h.capitalize(name) %> = () => ({
+  type: GET_<%= name.toUpperCase() %>_START,
+});

--- a/_templates/module/new/inject-reducer.ejs.t
+++ b/_templates/module/new/inject-reducer.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: source/js/reducers/index.js
+after: 'import { combineReducers } from "redux";'
+skip_if: "import <%= name %> from 'reducers/<%= name %>';"
+---
+import <%= name %> from 'reducers/<%= name %>';

--- a/_templates/module/new/reducer.ejs.t
+++ b/_templates/module/new/reducer.ejs.t
@@ -1,0 +1,45 @@
+---
+to: source/js/reducers/<%= name %>.js
+---
+
+import { Map } from 'immutable';
+
+import {
+  GET_<%= name.toUpperCase() %>_START,
+  GET_<%= name.toUpperCase() %>_ERROR,
+  GET_<%= name.toUpperCase() %>_SUCCESS,
+} from 'actions/<%= name %>';
+
+const initialState = Map({
+  loading: false,
+  error: null,
+  <%= name %>: null,
+});
+
+const actionsMap = {
+  // Async action
+  [GET_<%= name.toUpperCase() %>_START]: (state) => {
+    return state.merge(Map({
+      loading: true,
+      error: null,
+      <%= name %>: null,
+    }));
+  },
+  [GET_<%= name.toUpperCase() %>_ERROR]: (state, action) => {
+    return state.merge(Map({
+      loading: false,
+      error: action.error.message,
+    }));
+  },
+  [GET_<%= name.toUpperCase() %>_SUCCESS]: (state, action) => {
+    return state.merge(Map({
+      loading: false,
+      <%= name %>: action.data,
+    }));
+  },
+};
+
+export default function reducer(state = initialState, action = {}) {
+  const fn = actionsMap[action.type];
+  return fn ? fn(state, action) : state;
+}

--- a/_templates/module/new/register-reducer.ejs.t
+++ b/_templates/module/new/register-reducer.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: source/js/reducers/index.js
+after: "export default combineReducers\\(\\{"
+skip_if: "<%= name %>,"
+---
+  <%= name %>,

--- a/_templates/saga/new/action.ejs.t
+++ b/_templates/saga/new/action.ejs.t
@@ -1,0 +1,14 @@
+---
+to: source/js/actions/<%= name %>.js
+---
+
+export const GET_<%= name.toUpperCase() %>_START = "GET_<%= name.toUpperCase() %>_START";
+export const GET_<%= name.toUpperCase() %>_ERROR = "GET_<%= name.toUpperCase() %>_ERROR";
+export const GET_<%= name.toUpperCase() %>_SUCCESS = "GET_<%= name.toUpperCase() %>_SUCCESS";
+
+
+export function get<%= h.capitalize(name) %>() {
+  return {
+    type: GET_<%= name.toUpperCase() %>_START,
+  };
+}

--- a/_templates/saga/new/inject-saga.ejs.t
+++ b/_templates/saga/new/inject-saga.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: source/js/sagas/index.js
+after: import { all } from "redux-saga/effects";
+skip_if: import <%= name %>Sagas from "sagas/<%= name %>";
+---
+import <%= name %>Sagas from "sagas/<%= name %>";

--- a/_templates/saga/new/register-saga.ejs.t
+++ b/_templates/saga/new/register-saga.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: source/js/sagas/index.js
+after: "yield all\\(\\["
+skip_if: "...<%= name %>Sagas,"
+---
+    ...<%= name %>Sagas,

--- a/_templates/saga/new/saga.ejs.t
+++ b/_templates/saga/new/saga.ejs.t
@@ -1,0 +1,40 @@
+---
+to: source/js/sagas/<%= name %>.js
+---
+import { takeLatest, call, put } from "redux-saga/effects";
+
+import {
+  GET_<%= name.toUpperCase() %>_START,
+  GET_<%= name.toUpperCase() %>_ERROR,
+  GET_<%= name.toUpperCase() %>_SUCCESS,
+} from "actions/<%= name %>";
+
+import api from "api";
+
+// -------- Get <%= name %>
+
+function createGet<%= h.capitalize(name) %>() {
+  return function* (options) { // eslint-disable-line consistent-return
+    try {
+      const data = yield call(() => api.get<%= h.capitalize(name) %>(options.id));
+      const action = { type: GET_<%= name.toUpperCase() %>_SUCCESS, data };
+
+      yield put(action);
+    } catch (error) {
+      const action = { type: GET_<%= name.toUpperCase() %>_ERROR, error };
+
+      yield put(action);
+    }
+  };
+}
+
+export const get<%= h.capitalize(name) %> = createGet<%= h.capitalize(name) %>();
+
+export function* get<%= h.capitalize(name) %>Watcher() {
+  yield takeLatest(GET_<%= name.toUpperCase() %>_START, get<%= h.capitalize(name) %>);
+}
+
+
+export default [
+  get<%= h.capitalize(name) %>Watcher(),
+]


### PR DESCRIPTION
Hey Folks,

First off, thanks for the awesome boilerplate! I'm using it for a couple projects and really enjoying it.

One things we've enjoyed using alongside Marvin is [hygen](http://www.hygen.io/) templating. I'm not sure if this follows the direction you're headed with this repo, but I figured I'd open a PR in case this is something you folks find useful too.

The templates are in the `_templates` directory and the three existing template commands are:
```
hygen component new --name whatever
hygen module new --name whatever
hygen saga new --name whatever
```

These will drop in and hook up the various boilerplate files for sagas, reducers, or components. It's helped us speed up development by lowering the amount of copy/paste involved.